### PR TITLE
chore: Added Apple arm64 build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       run: |
         cd DprintPluginRoslyn/bin/Release/net6.0/osx-x64
         zip -r ../../../../../dprint-plugin-roslyn-x86_64-apple-darwin.zip ./*
-        cd DprintPluginRoslyn/bin/Release/net6.0/osx.12-arm64
+        cd ../osx.12-arm64
         zip -r ../../../../../dprint-plugin-roslyn-aarch64-apple-darwin.zip ./*
         cd ../linux-x64
         zip -r ../../../../../dprint-plugin-roslyn-x86_64-unknown-linux-gnu.zip ./*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,14 +41,11 @@ jobs:
 
     - name: Package
       run: |
-        cd DprintPluginRoslyn/bin/Release/net6.0/osx-x64
-        zip -r ../../../../../dprint-plugin-roslyn-x86_64-apple-darwin.zip ./*
-        cd ../osx.12-arm64
-        zip -r ../../../../../dprint-plugin-roslyn-aarch64-apple-darwin.zip ./*
-        cd ../linux-x64
-        zip -r ../../../../../dprint-plugin-roslyn-x86_64-unknown-linux-gnu.zip ./*
-        cd ../win-x64
-        zip -r ../../../../../dprint-plugin-roslyn-x86_64-pc-windows-msvc.zip ./*
+        RELEASE_DIR=$GITHUB_WORKSPACE/DprintPluginRoslyn/bin/Release/net6.0
+        zip -r dprint-plugin-roslyn-x86_64-apple-darwin.zip $RELEASE_DIR/osx-x64/*
+        zip -r dprint-plugin-roslyn-aarch64-apple-darwin.zip $RELEASE_DIR/osx.12-arm64/*
+        zip -r dprint-plugin-roslyn-x86_64-unknown-linux-gnu.zip $RELEASE_DIR/linux-x64/*
+        zip -r dprint-plugin-roslyn-x86_64-pc-windows-msvc.zip $RELEASE_DIR/win-x64/*
     - name: Create plugin file
       run: deno run --allow-read=. --allow-write=. scripts/create_plugin_file.ts
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,14 +34,17 @@ jobs:
 
     - name: Build (Release)
       run: |
-        dotnet build DprintPluginRoslyn -c Release --runtime win-x64
-        dotnet build DprintPluginRoslyn -c Release --runtime linux-x64
-        dotnet build DprintPluginRoslyn -c Release --runtime osx-x64
+        dotnet build DprintPluginRoslyn -c Release --self-contained --runtime win-x64
+        dotnet build DprintPluginRoslyn -c Release --self-contained --runtime linux-x64
+        dotnet build DprintPluginRoslyn -c Release --self-contained --runtime osx-x64
+        dotnet build DprintPluginRoslyn -c Release --self-contained --runtime osx.12-arm64
 
     - name: Package
       run: |
         cd DprintPluginRoslyn/bin/Release/net6.0/osx-x64
         zip -r ../../../../../dprint-plugin-roslyn-x86_64-apple-darwin.zip ./*
+        cd DprintPluginRoslyn/bin/Release/net6.0/osx.12-arm64
+        zip -r ../../../../../dprint-plugin-roslyn-aarch64-apple-darwin.zip ./*
         cd ../linux-x64
         zip -r ../../../../../dprint-plugin-roslyn-x86_64-unknown-linux-gnu.zip ./*
         cd ../win-x64
@@ -67,6 +70,7 @@ jobs:
       with:
         files: |
           dprint-plugin-roslyn-x86_64-apple-darwin.zip
+          dprint-plugin-roslyn-aarch64-apple-darwin.zip
           dprint-plugin-roslyn-x86_64-unknown-linux-gnu.zip
           dprint-plugin-roslyn-x86_64-pc-windows-msvc.zip
           plugin.exe-plugin

--- a/scripts/create_plugin_file.ts
+++ b/scripts/create_plugin_file.ts
@@ -16,6 +16,7 @@ await processPlugin.createDprintOrgProcessPlugin({
   version,
   platforms: [
     "darwin-x86_64",
+    "darwin-aarch64",
     "linux-x86_64",
     "windows-x86_64",
   ],


### PR DESCRIPTION
I have no idea if this is enough. I modeled the changes after https://github.com/dprint/dprint/pull/469

The `--self-contained` was previously the default whenever runtime is specified

https://docs.microsoft.com/en-us/dotnet/core/compatibility/sdk/6.0/runtimeidentifier-self-contained