### PR TITLE
ci: switch to the macos-14 runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
     name: test_release
-    runs-on: ubuntu-latest
+    runs-on: macos-14
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Builds for osx-arm64 were not getting adhoc code-signed, making the binaries get killed on startup.

The .NET SDK only invokes codesign on a macOS machine according to https://github.com/dotnet/sdk/issues/34917.

Closes #12
Closes #8

---

This is the easiest solution to the issue, as luckily all of the used GitHub actions are compatible, but alternatively using [https://github.com/indygreg/apple-platform-rs](apple-platform-rs) to codesign the binaries manually is also an option.