### PR TITLE
chore: modernize CI deps and refresh README install section

### DIFF
--- a/.github/workflows/ci.generated.yml
+++ b/.github/workflows/ci.generated.yml
@@ -24,9 +24,9 @@ jobs:
       - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5
         with:
           dotnet-version: 10.0.x
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: 22.x
+          node-version: 24.x
           registry-url: 'https://registry.npmjs.org'
       - name: Build (Debug)
         run: dotnet build DprintPluginRoslyn

--- a/.github/workflows/ci.ts
+++ b/.github/workflows/ci.ts
@@ -62,8 +62,8 @@ workflow({
         with: { "dotnet-version": "10.0.x" },
       },
       {
-        uses: "actions/setup-node@v4",
-        with: { "node-version": "22.x", "registry-url": "https://registry.npmjs.org" },
+        uses: "actions/setup-node@v6",
+        with: { "node-version": "24.x", "registry-url": "https://registry.npmjs.org" },
       },
       {
         name: "Build (Debug)",

--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ Wrapper around [Roslyn](https://github.com/dotnet/roslyn) in order to use it as 
 ## Install
 
 1. Install [dprint](https://dprint.dev/install/)
-2. Follow instructions at https://github.com/dprint/dprint-plugin-roslyn/releases/
+1. Run `dprint init`
+1. Run `dprint add roslyn`
+   - Or install from npm: `dprint add npm:@dprint/roslyn`
 
 ## Configuration
 


### PR DESCRIPTION
## Summary
- Bump `actions/setup-node` to v6 (node 24.x, was v4/22.x) in `ci.ts`; regenerate `ci.generated.yml`.
- Refresh the README Install section: replace the stale "follow releases" pointer with the standard `dprint init` / `dprint add roslyn` steps and add `dprint add npm:@dprint/roslyn` as an alternative.

## Test plan
- [ ] CI passes on this branch.