### PR TITLE
fix: preserve BOM for UTF-8 encoded files

### DIFF
--- a/DprintPluginRoslyn.Tests/WorkspaceTests.cs
+++ b/DprintPluginRoslyn.Tests/WorkspaceTests.cs
@@ -1,7 +1,9 @@
 using Dprint.Plugins.Roslyn.Configuration;
 using NUnit.Framework;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
+using System.Threading;
 
 namespace Dprint.Plugins.Roslyn;
 
@@ -44,5 +46,34 @@ public class WorkspaceTests
         workspace.SetConfig(2, new(), pluginConfig);
         var diagnostics = workspace.GetDiagnostics(2);
         Assert.That(diagnostics.Count, Is.EqualTo(0));
+    }
+
+    [Test]
+    public void FormatCode_WithBom_PreservesBomWhenContentChanges()
+    {
+        var workspace = new Workspace();
+        workspace.SetConfig(1, new(), new());
+        var bom = Encoding.UTF8.GetPreamble();
+        var content = Encoding.UTF8.GetBytes("namespace Test    {   }\n");
+        var input = bom.Concat(content).ToArray();
+
+        var result = workspace.GetFormatters(1).FormatCode("file.cs", input, null, CancellationToken.None);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Take(3).ToArray(), Is.EqualTo(bom));
+    }
+
+    [Test]
+    public void FormatCode_WithBom_ReturnsNullWhenUnchanged()
+    {
+        var workspace = new Workspace();
+        workspace.SetConfig(1, new(), new());
+        var bom = Encoding.UTF8.GetPreamble();
+        var content = Encoding.UTF8.GetBytes("namespace Test { }\n");
+        var input = bom.Concat(content).ToArray();
+
+        var result = workspace.GetFormatters(1).FormatCode("file.cs", input, null, CancellationToken.None);
+
+        Assert.That(result, Is.Null);
     }
 }

--- a/DprintPluginRoslyn/Formatters/CSharpCodeFormatter.cs
+++ b/DprintPluginRoslyn/Formatters/CSharpCodeFormatter.cs
@@ -29,7 +29,7 @@ public class CSharpCodeFormatter : ICodeFormatter
         return filePath.EndsWith(".cs", StringComparison.OrdinalIgnoreCase);
     }
 
-    public byte[] FormatText(SourceText text, TextSpan? range, OptionSet options, CancellationToken token)
+    public SourceText FormatText(SourceText text, TextSpan? range, OptionSet options, CancellationToken token)
     {
         SyntaxNode formattedNode;
 
@@ -39,8 +39,8 @@ public class CSharpCodeFormatter : ICodeFormatter
             formattedNode = Formatter.Format(root, range.Value, _workspace, options, token);
         else
             formattedNode = Formatter.Format(root, _workspace, options, token);
-        var result = formattedNode.GetText(text.Encoding, text.ChecksumAlgorithm);
-        return (result.Encoding ?? System.Text.Encoding.UTF8).GetBytes(result.ToString());
+
+        return formattedNode.GetText(text.Encoding, text.ChecksumAlgorithm);
     }
 
     public void ResolveConfiguration(ConfigurationResolutionContext context)

--- a/DprintPluginRoslyn/Formatters/CodeFormatters.cs
+++ b/DprintPluginRoslyn/Formatters/CodeFormatters.cs
@@ -1,4 +1,5 @@
 using Dprint.Plugins.Roslyn.Communication;
+using Dprint.Plugins.Roslyn.Utils;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Options;
 using Microsoft.CodeAnalysis.Text;
@@ -31,7 +32,8 @@ public class CodeFormatters
             encoding: null  // Let it auto-detect
         );
         var result = formatter.FormatText(sourceText, range, _options, token);
-        return result.SequenceEqual(code) ? null : result;
+        var bytes = result.GetBytes();
+        return bytes.SequenceEqual(code) ? null : bytes;
     }
 
     public Dictionary<string, object> GetResolvedConfig()

--- a/DprintPluginRoslyn/Formatters/ICodeFormatter.cs
+++ b/DprintPluginRoslyn/Formatters/ICodeFormatter.cs
@@ -10,7 +10,7 @@ public interface ICodeFormatter
 {
     string RoslynLanguageName { get; }
     bool ShouldFormat(string filePath);
-    byte[] FormatText(SourceText text, TextSpan? range, OptionSet options, CancellationToken token);
+    SourceText FormatText(SourceText text, TextSpan? range, OptionSet options, CancellationToken token);
     void ResolveConfiguration(ConfigurationResolutionContext context);
     IEnumerable<(string, object)> GetResolvedConfig(OptionSet options);
 }

--- a/DprintPluginRoslyn/Formatters/VisualBasicCodeFormatter.cs
+++ b/DprintPluginRoslyn/Formatters/VisualBasicCodeFormatter.cs
@@ -27,7 +27,7 @@ public class VisualBasicCodeFormatter : ICodeFormatter
         return filePath.EndsWith(".vb", StringComparison.OrdinalIgnoreCase);
     }
 
-    public byte[] FormatText(SourceText text, TextSpan? range, OptionSet options, CancellationToken token)
+    public SourceText FormatText(SourceText text, TextSpan? range, OptionSet options, CancellationToken token)
     {
         SyntaxNode formattedNode;
 
@@ -37,8 +37,8 @@ public class VisualBasicCodeFormatter : ICodeFormatter
             formattedNode = Formatter.Format(root, range.Value, _workspace, options, token);
         else
             formattedNode = Formatter.Format(root, _workspace, options, token);
-        var result = formattedNode.GetText(text.Encoding, text.ChecksumAlgorithm);
-        return (result.Encoding ?? System.Text.Encoding.UTF8).GetBytes(result.ToString());
+
+        return formattedNode.GetText(text.Encoding, text.ChecksumAlgorithm);
     }
 
     public void ResolveConfiguration(ConfigurationResolutionContext context)

--- a/DprintPluginRoslyn/Utils/SourceTextExtensions.cs
+++ b/DprintPluginRoslyn/Utils/SourceTextExtensions.cs
@@ -1,0 +1,16 @@
+using System.IO;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Dprint.Plugins.Roslyn.Utils;
+
+public static class SourceTextExtensions
+{
+    public static byte[] GetBytes(this SourceText sourceText)
+    {
+        var ms = new MemoryStream();
+        using var sw = new StreamWriter(ms, sourceText.Encoding);
+        sw.Write(sourceText.ToString());
+        sw.Flush();
+        return ms.ToArray();
+    }
+}

--- a/test/src/lib.rs
+++ b/test/src/lib.rs
@@ -78,6 +78,34 @@ mod test {
         })
         .await;
       assert_eq!(result.unwrap(), Some("namespace Test    {\n    class Test { }\n}\n".to_string(),));
+
+      // BOM preservation: content needs formatting
+      let result = communicator
+        .format_text(ProcessPluginCommunicatorFormatRequest {
+          file_path: PathBuf::from("file.cs"),
+          file_text: "\u{FEFF}namespace Test    {   }\n".to_string(),
+          range: None,
+          config_id,
+          override_config: Default::default(),
+          on_host_format: Rc::new(|_| unreachable!()),
+          token: token.clone(),
+        })
+        .await;
+      assert_eq!(result.unwrap(), Some("\u{FEFF}namespace Test { }\n".to_string()));
+
+      // BOM preservation: already formatted, should be unchanged
+      let result = communicator
+        .format_text(ProcessPluginCommunicatorFormatRequest {
+          file_path: PathBuf::from("file.cs"),
+          file_text: "\u{FEFF}namespace Test { }\n".to_string(),
+          range: None,
+          config_id,
+          override_config: Default::default(),
+          on_host_format: Rc::new(|_| unreachable!()),
+          token: token.clone(),
+        })
+        .await;
+      assert_eq!(result.unwrap(), None);
     }
 
     let mut handles = Vec::new();


### PR DESCRIPTION
**Issue**

When formatting a file with a UTF-8 BOM, the plugin stripped it. This was causing a large number of diffs in my organization's repository, as it seems Visual Studio defaults to outputting files in UTF-8 with a BOM (for no apparent reason). This PR attempts to address this and preserve the same encoding as the input.

The root cause was in how `SourceText` was serialized back to bytes: `SourceText.From(stream, encoding: null)` correctly detected the BOM and set `sourceText.Encoding` to a BOM-emitting `UTF8Encoding`, but the formatters discarded that information by calling `Encoding.GetBytes(string)`, which never writes a preamble regardless of the encoding's configuration (see the remarks section [here](https://learn.microsoft.com/en-us/dotnet/api/system.text.utf8encoding?view=net-10.0#remarks) for more information).

**Fix**

There are a few changes here, not all of which are strictly necessary:

1. I decided to move where text encoding is performed, from the individual formatters and into `CodeFormatters`. So `ICodeFormatter.FormatText` now returns `SourceText` instead of `byte[]`. If there's any particular opposition to this, I'm happy to do it differently. 

2. Added a new extension `SourceTextExtensions.GetBytes()` which serializes a `SourceText` to bytes using `StreamWriter(stream, sourceText.Encoding)`. Unlike `Encoding.GetBytes(string)`, `StreamWriter` writes the encoding's preamble (the BOM) at the start of the stream when the encoding specifies one.

3. `CodeFormatters.FormatCode` now calls `result.GetBytes()` on the returned `SourceText` to get the final byte output.

The result is that files with a UTF-8 BOM format have the BOM preserved, while files without one are unaffected.